### PR TITLE
delete own lock if not acquirable

### DIFF
--- a/jobslib/liveness/__init__.py
+++ b/jobslib/liveness/__init__.py
@@ -78,7 +78,7 @@ class BaseLiveness(abc.ABC):
 class CheckLiveness(_Task):
     """
     Internal task which checks age of the liveness stamp. Returns exit
-    code :const:`0` if check passes, :const:`0` if check fails.
+    code :const:`0` if check passes, :const:`1` if check fails.
     """
 
     name = 'check-liveness'


### PR DESCRIPTION
If task is terminated hard by *sigkill*, jobslib does not release lock. If lock ttl is high, e.g. 60min, nobody is able to acquire lock for a long time, even the former lock creator itself.